### PR TITLE
fix/remove unnecessary mutex

### DIFF
--- a/packages/util/src/oqueue.ts
+++ b/packages/util/src/oqueue.ts
@@ -138,7 +138,8 @@ export class OQ<S, T = void> {
 
 		const [workPromise, resolveReadyForWork] = extractPromise<void>()
 
-		let release = await this._m.acquire()
+		//TODO: Investigate why this lock is here and if it is actually needed
+		// let release = await this._m.acquire()
 		const i = this._queue.findIndex(([n2]) => n < n2)
 		this._queue.splice(i == -1 ? this._queue.length : i, 0, [n, resolveReadyForWork])
 
@@ -149,7 +150,8 @@ export class OQ<S, T = void> {
 		}
 
 		this._u++
-		release()
+		//TODO: Investigate why this lock is here and if it is actually needed
+		// release()
 
 		await workPromise
 
@@ -188,7 +190,7 @@ export class OQ<S, T = void> {
 		// console.log("checkout: " + n)
 
 		const v = await cfn(await Promise.resolve(w), n)
-		release = await this._m.acquire()
+		const release = await this._m.acquire()
 		this._o++
 		this._e.dispatchEvent(new ProgressEvent("checkout", { loaded: this._o }))
 		release()


### PR DESCRIPTION
## Purpose
Upon digging into the add method, found that the last part is always failing on Safari and mobile Firefox

## Notes
Unclear why this is needed in the first place, since everything is async/awaited and add function is only being used in one place

## Test Cases
- [x] Uploads work as expected on Safari
- [x] Uploads work as expected on FF
- [x] Uploads work as expected on Chrome
- [x] Downloads work as expected on Safari
- [x] Downloads work as expected on FF
- [x] Downloads work as expected on Chrome

Unable to test on Mobile devices because of HTTPS issues, need to deploy to test this one

### Firefox
<img width="2560" alt="Screen Shot 2021-12-21 at 2 37 14 PM" src="https://user-images.githubusercontent.com/1796568/146995083-4c102db4-f330-49db-a6da-43eecd6aa09e.png">

### Chrome
<img width="2560" alt="Screen Shot 2021-12-21 at 2 34 03 PM" src="https://user-images.githubusercontent.com/1796568/146995064-98059792-04b3-4555-bcdd-c42f820a966d.png">

### Safari
<img width="2560" alt="Screen Shot 2021-12-21 at 2 37 07 PM" src="https://user-images.githubusercontent.com/1796568/146995070-971e009a-319e-4ea4-804b-c18821346c21.png">

** DO NOT MERGE UNTIL WEB2 DEV IS VERIFIED IN THE DEPLOY **